### PR TITLE
デバックでログを見るための実装。

### DIFF
--- a/src/main/java/com/lesson9/Bandlist/BandServiceImpl.java
+++ b/src/main/java/com/lesson9/Bandlist/BandServiceImpl.java
@@ -1,5 +1,8 @@
 package com.lesson9.Bandlist;
 
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.time.ZonedDateTime;
@@ -9,6 +12,8 @@ import java.util.stream.Collectors;
 
 @Service
 public class BandServiceImpl implements BandService {
+    private final Logger logger = LoggerFactory.getLogger(BandServiceImpl.class);
+
     private BandMapper bandMapper;
 
     public BandServiceImpl(BandMapper bandMapper) {
@@ -23,28 +28,19 @@ public class BandServiceImpl implements BandService {
         return bandMapper.findById(id);
     }
     @Override
-    public List<Band> getBandsByDate(ZonedDateTime date){
+    public List<Band> getBandsByDate(ZonedDateTime date) {
         List<Band> allBands = bandMapper.findAll();
-        return allBands.stream().filter(band -> {
-            ZonedDateTime announcementDate = band.getActAnnouncementDate();
-            return announcementDate != null && announcementDate.isBefore(date);
-        })
-                .collect(Collectors.toList());
-    }
-//    @Override
-//    public void create(String name) {
-//        Band newBand = new Band();
-//        newBand.setBandName(name);
-//        bandMapper.create(newBand);
-//    }
-//    @Override
-//    public void update(int id, String name) throws Exception {
-//        Band bandToUpdate = bandMapper.findById(id);
-//        if(bandToUpdate == null) {
-//            throw new Exception("Band not found with ID: " + id);
-//        }
-//        bandToUpdate.setBandName(name);
-//        bandMapper.update(bandToUpdate);
-//    }
-}
+        logger.debug("All bands from the database: {}", allBands);
+        logger.debug("Query date: {}", date);
 
+        List<Band> filteredBands = allBands.stream().filter(band -> {
+            ZonedDateTime announcementDate = band.getActAnnouncementDate();
+            logger.debug("Band: {}, Announcement Date: {}", band.getBandName(), announcementDate);
+            return announcementDate != null && announcementDate.isBefore(date);
+        }).collect(Collectors.toList());
+
+        logger.debug("Filtered bands: {}", filteredBands);
+
+        return filteredBands;
+    }
+}


### PR DESCRIPTION
# GETリクエスト
■問題なくレスポンスされる。
```curl --location 'http://localhost:8080/bands/all/names'```
<br>
■サーバーエラーで返ってくる。
やりたいこととしてはリクエスト日以前の日付のレコードを持つバンド名をレスポンスしたい。
未来の日付をレコードに持つバンドに関してはまだ出演発表をしていないのでレスポンスをしたくないという想定。(DBにはまだ未来の日付が紐づいたバンドは未登録)
```
curl --location 'http://localhost:8080/bands/announced/names'
{
    "timestamp": "2023-08-25T06:13:16.682+00:00",
    "status": 500,
    "error": "Internal Server Error",
    "path": "/bands/announced/names"
}
```


### 原因
データベースから取得した値が null となっている。
(予想)
* bandMapper.findAll() が正しくデータを取得していない
→問題なくレスポンスされているGETリクエストがあるため findAll() はデータ取得できている。

* act_Announcement_Date のカラムの値が正しく格納されていない
→show tables; で確認したところ問題なく登録されている。

* BandController クラス内の announcedBandNames メソッドにおいて、currentDate の値が正しく取得できていない。

* BandServiceImpl クラス内の band.getActAnnouncementDate() がnullを返している可能性が高い。

下二つは確認方法がわかりませんでした。
デバックはライブラリを経由するため一つ一つ見ていくことが困難だと判断して
ログで確認できる方法のコードを書きましたが引き続き原因の特定はできませんでした。

追記：元のコードは下記です。
https://github.com/ABECKCROW/lecture09/tree/feature-GET